### PR TITLE
Add secondary attempt to count a word after trimming punctuation

### DIFF
--- a/src/counting.rs
+++ b/src/counting.rs
@@ -10,13 +10,20 @@ pub struct Uncountable;
 pub fn count_line(line: &str) -> Result<usize, Uncountable> {
     let word_syllables = line
         .split_whitespace()
-        .map(|word| count_word(word.to_owned()))
+        .map(|word| count_word(word))
         .collect::<Result<Vec<usize>, Uncountable>>()?;
     Ok(word_syllables.into_iter().sum())
 }
+fn count_word(word: &str) -> Result<usize, Uncountable> {
+    match count_word_strict(word.to_owned()) {
+        Ok(count) => Ok(count),
+        // Try again after trimming punctuation
+        Err(_) => count_word_strict(word.trim_matches(|c: char| !c.is_alphanumeric()).to_owned()),
+    }
+}
 
 #[cached(size = 1000)]
-fn count_word(word: String) -> Result<usize, Uncountable> {
+fn count_word_strict(word: String) -> Result<usize, Uncountable> {
     lazy_static! {
         static ref WORD_REGEX: Regex = Regex::new(r"^[\w']+$").unwrap();
     }
@@ -52,7 +59,7 @@ pub fn is_haiku_single(line: &str) -> Result<Option<[String; 3]>, Uncountable> {
     let mut syllable_count = 0;
     let mut lines = [Vec::new(), Vec::new(), Vec::new()];
     for word in line.split_whitespace() {
-        syllable_count += count_word(word.to_owned())?;
+        syllable_count += count_word(word)?;
         match syllable_count {
             x if x <= 5 => lines[0].push(word.to_owned()),
             x if x <= 12 => lines[1].push(word.to_owned()),
@@ -73,23 +80,28 @@ mod test {
 
     #[test]
     fn test_count_word() {
-        assert_eq!(count_word("ABUNDANT".to_owned()), Ok(3));
-        assert_eq!(count_word("abundant".to_owned()), Ok(3));
-        assert_eq!(count_word("abUNdaNT".to_owned()), Ok(3));
-        assert_eq!(count_word("a".to_owned()), Ok(1));
-        assert_eq!(count_word("A".to_owned()), Ok(1));
-        assert_eq!(count_word("Don't".to_owned()), Ok(1));
-        assert_eq!(count_word("X Y Z".to_owned()), Err(Uncountable));
-        assert_eq!(count_word("XYZ".to_owned()), Err(Uncountable));
-        assert_eq!(count_word("#$&^%&".to_owned()), Err(Uncountable));
+        assert_eq!(count_word("ABUNDANT"), Ok(3));
+        assert_eq!(count_word("abundant"), Ok(3));
+        assert_eq!(count_word("abUNdaNT"), Ok(3));
+        assert_eq!(count_word("a"), Ok(1));
+        assert_eq!(count_word("A"), Ok(1));
+        assert_eq!(count_word("Don't"), Ok(1));
+        assert_eq!(count_word("'Allo"), Ok(2));
+        assert_eq!(count_word("Allo"), Err(Uncountable));
+        assert_eq!(count_word("X Y Z"), Err(Uncountable));
+        assert_eq!(count_word("XYZ"), Err(Uncountable));
+        assert_eq!(count_word("#$&^%&"), Err(Uncountable));
     }
 
     #[test]
-    fn test_count_words() {
+    fn test_count_line() {
         assert_eq!(count_line("A B C"), Ok(3));
         assert_eq!(count_line("Abundant haiku"), Ok(5));
         assert_eq!(count_line("Uses a dictionary"), Ok(7));
         assert_eq!(count_line("Database to come"), Ok(5));
+        assert_eq!(count_line("'Allo 'allo"), Ok(4));
+        assert_eq!(count_line("'Hello there'"), Ok(3));
+        assert_eq!(count_line("\"Hello there.\" said General Kenobi."), Ok(10));
     }
 
     #[test]
@@ -102,6 +114,16 @@ mod test {
                 "The last winter leaves".to_owned(),
                 "Clinging to the black branches".to_owned(),
                 "Explode into birds".to_owned()
+            ]))
+        );
+        assert_eq!(
+            is_haiku_single(
+                "The last winter leaves, clinging to the black branches, explode into birds."
+            ),
+            Ok(Some([
+                "The last winter leaves,".to_owned(),
+                "clinging to the black branches,".to_owned(),
+                "explode into birds.".to_owned()
             ]))
         );
         assert_eq!(
@@ -123,6 +145,11 @@ mod test {
         assert!(is_haiku(&[
             "The last winter leaves".to_owned(),
             "Clinging to the black branches".to_owned(),
+            "Explode into birds".to_owned()
+        ]));
+        assert!(is_haiku(&[
+            "The last 'winter' leaves.".to_owned(),
+            "Clinging to the black branches.".to_owned(),
             "Explode into birds".to_owned()
         ]));
         assert!(!is_haiku(&[


### PR DESCRIPTION
- Allows haikubot to count properly punctuated lines
- Addresses #1